### PR TITLE
Fix naming for images that are not shown

### DIFF
--- a/_sass/includes.scss
+++ b/_sass/includes.scss
@@ -143,7 +143,7 @@
   }
   &__coc {
     background-size: 60%;
-    background-image: url(../images/coc.svg);
+    background-image: url(../images/COC.svg);
     background-position: 100% 16%;
     @media (min-width: 500px)  {
       background-size: 55%;

--- a/_sass/pages.scss
+++ b/_sass/pages.scss
@@ -735,7 +735,7 @@
     }
     &__expected-behavior {
         background-size: 50%;
-        background-image: url(../images/Do.svg);
+        background-image: url(../images/DO.svg);
         background-position: 100% 4%;
         @media (min-width: 600px)  {
             background-position: 95% 4%;


### PR DESCRIPTION
Some illustrations were not displayed on the Code of Conduct page, I changed their names to fix this error